### PR TITLE
Cafe header/logo polish (Astra) + keep internal menu links in same tab

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,3 +6,19 @@ add_action('wp_enqueue_scripts', function () {
     // Child theme stylesheet (use this for your custom CSS)
     wp_enqueue_style('astra-child', get_stylesheet_uri(), ['astra-parent'], wp_get_theme()->get('Version'));
 });
+
+/**
+ * Force internal menu links to open in the same tab (no target="_blank").
+ * This prevents the Cafe menu item from opening in a new window.
+ */
+add_filter('nav_menu_link_attributes', function ($atts) {
+    if (empty($atts['href'])) return $atts;
+    $href = $atts['href'];
+    $site = home_url('/');
+    $is_relative = str_starts_with($href, '/');
+    $is_internal = $is_relative || str_starts_with($href, $site);
+    if ($is_internal && isset($atts['target'])) {
+        unset($atts['target']);
+    }
+    return $atts;
+}, 10, 1);

--- a/style.css
+++ b/style.css
@@ -5,5 +5,29 @@
  Description: Child theme to deploy pages and CSS from GitHub.
  Author: Rippleworks
  GitHub Theme URI: https://github.com/OWNER/astra-child-rippleworks
- GitHub Branch: main
+GitHub Branch: main
 */
+
+/* === Café page header polish (Astra) === */
+/* Target our template used by /cafe */
+.page-template-page-static-partial-php .site-header {
+  padding-top: 0;
+  padding-bottom: 0;
+  box-shadow: none; /* keep clean */
+}
+.page-template-page-static-partial-php .ast-primary-header-bar,
+.page-template-page-static-partial-php .ast-builder-grid-row {
+  min-height: 72px; /* consistent height */
+}
+/* Keep the logo tidy */
+.page-template-page-static-partial-php .site-logo-img img,
+.page-template-page-static-partial-php .custom-logo {
+  max-height: 56px;
+  height: auto;
+  width: auto;
+}
+/* Mobile logo sizing */
+@media (max-width: 768px) {
+  .page-template-page-static-partial-php .site-logo-img img,
+  .page-template-page-static-partial-php .custom-logo { max-height: 44px; }
+}


### PR DESCRIPTION
## Summary
- Tidy Café page header with scoped Astra CSS for consistent height and logo sizing
- Strip `target="_blank"` from internal navigation links so Café opens in the same tab

## Testing
- `php -l functions.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689975f8b3188320b994f8d38e464f69