### PR TITLE
Cafe header/logo polish (Astra) + keep internal menu links in same tab

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,3 +6,42 @@ add_action('wp_enqueue_scripts', function () {
     // Child theme stylesheet (use this for your custom CSS)
     wp_enqueue_style('astra-child', get_stylesheet_uri(), ['astra-parent'], wp_get_theme()->get('Version'));
 });
+
+/**
+ * Force internal menu links to open in the same tab (no target="_blank").
+ * This prevents the Cafe menu item from opening in a new window.
+ */
+add_filter('nav_menu_link_attributes', function ($atts, $item = null, $args = null, $depth = null) {
+    if (empty($atts['href'])) {
+        return $atts;
+    }
+
+    $href       = $atts['href'];
+    $site       = home_url('/');
+    $is_relative = strpos($href, '/') === 0;
+    $is_internal = $is_relative || strpos($href, $site) === 0;
+
+    if ($is_internal && isset($atts['target'])) {
+        unset($atts['target']);
+    }
+
+    return $atts;
+}, 20, 4);
+
+/**
+ * Replace the default logo with the RippleWorks brand on static partial pages
+ * like /cafe.
+ */
+add_filter('get_custom_logo', function ($html, $blog_id = 0) {
+    if (!is_page_template('page-static-partial.php')) {
+        return $html;
+    }
+
+    $home = esc_url(home_url('/'));
+
+    $svg = '<svg class="ripple" viewBox="0 0 40 40" aria-hidden="true"><defs><radialGradient id="rg" cx="50%" cy="50%"><stop offset="0%" stop-color="#00B8A9" /><stop offset="100%" stop-color="#BFF0E5" /></radialGradient></defs><circle class="r1" cx="20" cy="20" r="2"></circle><circle class="r2" cx="20" cy="20" r="2"></circle><circle class="r3" cx="20" cy="20" r="2"></circle></svg>';
+
+    $brand = '<span class="brand">' . $svg . 'RippleWorks</span>';
+
+    return '<a href="' . $home . '" class="custom-logo-link" rel="home">' . $brand . '</a>';
+}, 10, 2);

--- a/style.css
+++ b/style.css
@@ -5,5 +5,55 @@
  Description: Child theme to deploy pages and CSS from GitHub.
  Author: Rippleworks
  GitHub Theme URI: https://github.com/OWNER/astra-child-rippleworks
- GitHub Branch: main
+GitHub Branch: main
 */
+
+/* === Café page header polish (Astra) === */
+/* Target our template used by /cafe */
+.page-template-page-static-partial-php .site-header {
+  padding-top: 0;
+  padding-bottom: 0;
+  box-shadow: none; /* keep clean */
+}
+.page-template-page-static-partial-php .ast-primary-header-bar,
+.page-template-page-static-partial-php .ast-builder-grid-row {
+  min-height: 72px; /* consistent height */
+}
+/* Keep the logo tidy */
+.page-template-page-static-partial-php .site-logo-img img,
+.page-template-page-static-partial-php .custom-logo {
+  max-height: 56px;
+  height: auto;
+  width: auto;
+}
+/* Mobile logo sizing */
+@media (max-width: 768px) {
+  .page-template-page-static-partial-php .site-logo-img img,
+  .page-template-page-static-partial-php .custom-logo { max-height: 44px; }
+}
+
+/* RippleWorks brand logo from homepage */
+.page-template-page-static-partial-php .brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 900;
+  letter-spacing: .3px;
+}
+.page-template-page-static-partial-php .brand svg {
+  width: 38px;
+  height: 38px;
+}
+.page-template-page-static-partial-php .ripple circle {
+  fill: none;
+  stroke: url(#rg);
+  stroke-width: 2;
+}
+.page-template-page-static-partial-php .r1 { opacity: .8; animation: rip 2.8s linear infinite; }
+.page-template-page-static-partial-php .r2 { opacity: .5; animation: rip 2.8s linear infinite .6s; }
+.page-template-page-static-partial-php .r3 { opacity: .25; animation: rip 2.8s linear infinite 1.2s; }
+@keyframes rip {
+  0% { r: 2; stroke-opacity: .9; }
+  70% { r: 15; stroke-opacity: .25; }
+  100% { r: 18; stroke-opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- Tidy Café page header with scoped Astra CSS for consistent height and ripple-animated logo
- Strip `target="_blank"` from internal navigation links so Café opens in the same tab

## Testing
- `php -l functions.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689975f8b3188320b994f8d38e464f69