### PR TITLE
Fix specials card images on Café page

### DIFF
--- a/partials/cafe.html
+++ b/partials/cafe.html
@@ -85,10 +85,11 @@
     /* Specials */
     #cafe-demo .specials{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
     #cafe-demo .special-card{position:relative;background:var(--card);border:1px solid var(--border);border-radius:16px;overflow:hidden;box-shadow:0 10px 25px rgba(0,0,0,.12);transition:transform .2s,box-shadow .2s}
-    #cafe-demo .special-card img{width:100%;height:160px;object-fit:cover}
+    #cafe-demo .special-card .media{position:relative;height:160px}
+    #cafe-demo .special-card .media img{width:100%;height:100%;object-fit:cover}
     #cafe-demo .special-card h3{margin:12px 18px 6px;color:var(--text)}
     #cafe-demo .special-card p{margin:0 18px 40px;color:var(--muted);font-size:14px}
-    #cafe-demo .special-card .chip{position:absolute;top:12px;right:12px;background:var(--accent);color:#032b2a;font-weight:700;padding:4px 8px;border-radius:12px}
+    #cafe-demo .special-card .price-badge{position:absolute;top:12px;right:12px;background:var(--accent);color:#032b2a;font-weight:700;padding:4px 8px;border-radius:12px}
     #cafe-demo .special-card:hover{transform:translateY(-3px);box-shadow:0 12px 24px rgba(0,0,0,.15)}
 
     /* Gallery */
@@ -290,22 +291,28 @@
       <h2 class="section-title">This week’s specials</h2>
       <div class="specials">
         <div class="special-card reveal">
-          <img src="https://images.unsplash.com/photo-1541592106381-b31e9677c0e5?w=600&auto=format&fit=crop&q=80" alt="Caramel slice" loading="lazy" decoding="async">
+          <div class="media">
+            <img src="https://images.unsplash.com/photo-1546549039-49dcd4f7c8e8?q=80&w=1600&auto=format&fit=crop" alt="Caramel slice" loading="lazy" decoding="async">
+            <span class="price-badge">$4.5</span>
+          </div>
           <h3>Caramel slice</h3>
           <p>Homemade gooey caramel bar.</p>
-          <span class="chip">$4.5</span>
         </div>
         <div class="special-card reveal">
-          <img src="https://images.unsplash.com/photo-1541167760496-1628856ab772?w=600&auto=format&fit=crop&q=80" alt="Seasonal salad" loading="lazy" decoding="async">
+          <div class="media">
+            <img src="https://images.unsplash.com/photo-1540420773420-3366772f4999?q=80&w=1600&auto=format&fit=crop" alt="Seasonal salad" loading="lazy" decoding="async">
+            <span class="price-badge">$9</span>
+          </div>
           <h3>Seasonal salad</h3>
           <p>Fresh local greens with feta.</p>
-          <span class="chip">$9</span>
         </div>
         <div class="special-card reveal">
-          <img src="https://images.unsplash.com/photo-1607083206869-13e89128e414?w=600&auto=format&fit=crop&q=80" alt="Mocha deluxe" loading="lazy" decoding="async">
+          <div class="media">
+            <img src="https://images.unsplash.com/photo-1509042239860-f550ce710b93?q=80&w=1600&auto=format&fit=crop" alt="Mocha deluxe" loading="lazy" decoding="async">
+            <span class="price-badge">$6</span>
+          </div>
           <h3>Mocha deluxe</h3>
           <p>Rich cocoa shot with espresso.</p>
-          <span class="chip">$6</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace mismatched images in "This week’s specials" with placeholder photos
- Wrap each special's media in a container with overlay price badge and lazy-loading

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://images.unsplash.com/photo-1546549039-49dcd4f7c8e8?q=80&w=1600&auto=format&fit=crop` *(403 Forbidden, expected resource exists)*

------
https://chatgpt.com/codex/tasks/task_e_68999dd7960883209b8d9857a4c66abd