### PR TITLE
fix: restore cafe specials images

### DIFF
--- a/assets/cafe/specials/caramel-slice.svg
+++ b/assets/cafe/specials/caramel-slice.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
-  <rect width="400" height="300" fill="#f4e1c1"/>
-  <rect x="50" y="80" width="300" height="150" fill="#b5651d"/>
-  <rect x="50" y="60" width="300" height="40" fill="#5a3d30"/>
-</svg>

--- a/assets/cafe/specials/mocha-deluxe.svg
+++ b/assets/cafe/specials/mocha-deluxe.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
-  <rect width="400" height="300" fill="#f5e6da"/>
-  <rect x="120" y="80" width="160" height="140" rx="20" fill="#d2b48c"/>
-  <ellipse cx="200" cy="110" rx="80" ry="30" fill="#8b4513"/>
-  <ellipse cx="200" cy="110" rx="70" ry="20" fill="#5d4037"/>
-  <path d="M280 110 h40 v60 a30 30 0 0 1-30 30" fill="none" stroke="#d2b48c" stroke-width="20"/>
-</svg>

--- a/assets/cafe/specials/seasonal-salad.svg
+++ b/assets/cafe/specials/seasonal-salad.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
-  <rect width="400" height="300" fill="#f4f4f4"/>
-  <circle cx="200" cy="150" r="100" fill="#88c057"/>
-  <circle cx="170" cy="120" r="20" fill="#ffffff"/>
-  <circle cx="230" cy="180" r="20" fill="#ffffff"/>
-  <circle cx="200" cy="150" r="40" fill="#ef4444"/>
-</svg>

--- a/partials/cafe.html
+++ b/partials/cafe.html
@@ -292,7 +292,7 @@
       <div class="specials">
         <div class="special-card reveal">
           <div class="media">
-            <img src="/assets/cafe/specials/caramel-slice.svg" alt="Caramel slice" loading="lazy" decoding="async" width="400" height="160">
+            <img src="https://images.unsplash.com/photo-1546549039-49dcd4f7c8e8?auto=format&fit=crop&w=400&h=160&q=80" alt="Caramel slice" loading="lazy" decoding="async" width="400" height="160">
             <span class="price-badge">$4.5</span>
           </div>
           <h3>Caramel slice</h3>
@@ -300,7 +300,7 @@
         </div>
         <div class="special-card reveal">
           <div class="media">
-            <img src="/assets/cafe/specials/seasonal-salad.svg" alt="Seasonal salad" loading="lazy" decoding="async" width="400" height="160">
+            <img src="https://images.unsplash.com/photo-1540420773420-3366772f4999?auto=format&fit=crop&w=400&h=160&q=80" alt="Seasonal salad" loading="lazy" decoding="async" width="400" height="160">
             <span class="price-badge">$9</span>
           </div>
           <h3>Seasonal salad</h3>
@@ -308,7 +308,7 @@
         </div>
         <div class="special-card reveal">
           <div class="media">
-            <img src="/assets/cafe/specials/mocha-deluxe.svg" alt="Mocha deluxe" loading="lazy" decoding="async" width="400" height="160">
+            <img src="https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=400&h=160&q=80" alt="Mocha deluxe" loading="lazy" decoding="async" width="400" height="160">
             <span class="price-badge">$6</span>
           </div>
           <h3>Mocha deluxe</h3>


### PR DESCRIPTION
## Summary
- restore high-res photos for Café specials cards
- remove unused SVG placeholders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b1fbe65c83208524f4cccd71eafa