### PR TITLE
Fix orphaned Café gallery caption

### DIFF
--- a/partials/cafe.html
+++ b/partials/cafe.html
@@ -100,6 +100,12 @@
     #cafe-demo .gallery img{width:100%;display:block;border-radius:12px;margin-bottom:14px;transition:transform .2s,box-shadow .2s}
     #cafe-demo .gallery img:hover{transform:scale(1.02);box-shadow:0 8px 20px rgba(0,0,0,.15)}
 
+    /* Prevent captions or alt text from showing under gallery images */
+    #cafe-demo .gallery img::before,
+    #cafe-demo .gallery img::after{content:none !important}
+    #cafe-demo .gallery figcaption,
+    #cafe-demo .gallery .wp-caption-text{display:none !important}
+
     /* Reveal animations */
     #cafe-demo .reveal{opacity:0;transform:translateY(8px);transition:opacity .6s,transform .6s}
     #cafe-demo .reveal.visible{opacity:1;transform:none}
@@ -326,7 +332,7 @@
       <div class="gallery">
         <img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?auto=format&fit=crop&q=80&w=400" alt="Coffee beans" loading="lazy" decoding="async">
         <img src="https://images.unsplash.com/photo-1498804103079-a6351b050096?auto=format&fit=crop&q=80&w=400" alt="Latte art" loading="lazy" decoding="async">
-        <img src="https://images.unsplash.com/photo-1485808191679-72a5b0ae2ed9?auto=format&fit=crop&q=80&w=400" alt="Coffee setup" loading="lazy" decoding="async">
+          <img src="https://images.unsplash.com/photo-1485808191679-72a5b0ae2ed9?auto=format&fit=crop&q=80&w=400" alt="Coffee brewing tools on a table" loading="lazy" decoding="async">
         <img src="https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&q=80&w=400" alt="Pour over" loading="lazy" decoding="async">
         <img src="https://images.unsplash.com/photo-1464305795204-6f5bbfc7fb81?auto=format&fit=crop&q=80&w=400" alt="Croissant" loading="lazy" decoding="async">
         <img src="https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?auto=format&fit=crop&q=80&w=400" alt="Cafe interior" loading="lazy" decoding="async">
@@ -383,12 +389,28 @@
   </footer>
 
   <script>
-  (function(){
-    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    (function(){
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    const head = document.head;
-    const desc = 'Coastal Bean Café in Aldinga SA — coffee, bites & community.';
-    const hero = 'https://images.unsplash.com/photo-1498804103079-a6351b050096?auto=format&fit=crop&q=80&w=1200';
+      // Clean up any orphaned captions or empty images in the gallery
+      const gallery = document.querySelector('#cafe-demo #gallery');
+      if (gallery) {
+        gallery.querySelectorAll('img').forEach(img => {
+          const src = img.getAttribute('src');
+          if (!src || src.trim() === '') {
+            img.remove();
+          }
+        });
+        gallery.querySelectorAll('figcaption,p,span').forEach(cap => {
+          if (/coffee setup/i.test(cap.textContent)) {
+            cap.remove();
+          }
+        });
+      }
+
+      const head = document.head;
+      const desc = 'Coastal Bean Café in Aldinga SA — coffee, bites & community.';
+      const hero = 'https://images.unsplash.com/photo-1498804103079-a6351b050096?auto=format&fit=crop&q=80&w=1200';
     if(!head.querySelector('meta[name="description"]')){
       const m=document.createElement('meta');m.name='description';m.content=desc;head.appendChild(m);
       [['og:title','Coastal Bean Café'],['og:description',desc],['og:image',hero],['twitter:card','summary_large_image'],['twitter:title','Coastal Bean Café'],['twitter:description',desc],['twitter:image',hero]].forEach(([k,v])=>{const meta=document.createElement('meta');(k.startsWith('og:')?meta.setAttribute('property',k):meta.setAttribute('name',k));meta.content=v;head.appendChild(meta);});


### PR DESCRIPTION
## Summary
- hide gallery captions and pseudo-alt text
- remove empty caption images via script
- replace "Coffee setup" alt text with descriptive alternative

## Testing
- `npm test` *(fails: ENOENT: package.json not found)*
- `php -l partials/cafe.html`


------
https://chatgpt.com/codex/tasks/task_e_6899c3c994bc8320bea27a00cb0d0115