### PR TITLE
Add skip link and body scroll lock to Café page

### DIFF
--- a/partials/cafe.html
+++ b/partials/cafe.html
@@ -8,6 +8,13 @@
     #cafe-demo a{color:inherit;text-decoration:none}
     #cafe-demo .container{max-width:1040px;margin:0 auto;padding:0 20px}
 
+    /* Skip link */
+    #cafe-demo .skip-link{position:absolute;left:10px;top:-40px;background:var(--accent);color:#032b2a;padding:8px 14px;border-radius:8px;font-weight:600;z-index:1001;transition:top .2s}
+    #cafe-demo .skip-link:focus{top:10px}
+
+    /* Prevent body scroll when mobile menu open */
+    body.no-scroll{overflow:hidden}
+
     /* Buttons */
     #cafe-demo .btn{display:inline-flex;align-items:center;gap:10px;background:linear-gradient(135deg,var(--accent),#14b8a6);color:#032b2a;padding:12px 18px;border-radius:12px;font-weight:800;box-shadow:0 8px 20px rgba(20,184,166,.25);transition:transform .2s,box-shadow .2s}
     #cafe-demo .btn-outline{background:transparent;border:1px solid rgba(255,255,255,.7);color:#fff;padding:10px 14px;border-radius:10px;font-weight:700;transition:transform .2s,box-shadow .2s}
@@ -176,6 +183,7 @@
       #cafe-demo #rwMainNav .links a.active:after{display:none}
     }
   </style>
+  <a class="skip-link" href="#cafe-main">Skip to main content</a>
 
   <!-- === Café header === -->
   <header class="rw-site" id="rw-topbar">
@@ -207,7 +215,7 @@
       </nav>
     </div>
   </header>
-
+  <main id="cafe-main">
   <section class="hero" style="background:#1b1410">
     <div class="bg" aria-hidden="true"></div>
     <div class="overlay" aria-hidden="true"></div>
@@ -387,7 +395,7 @@
     </div>
   </section>
 
-
+  </main>
 
   <footer>
     <div class="container" style="color:#d6d3d1">Made with ☕ by RippleWorks</div>
@@ -431,29 +439,34 @@
     // Mobile menu toggle
     const nav = document.querySelector('#cafe-demo #rwMainNav');
     const btn = nav?.querySelector('.menu-toggle');
-    const links = nav?.querySelectorAll('.links a');
     if (btn && nav) {
+      const links = nav.querySelectorAll('.links a');
+      const closeMenu = () => {
+        nav.classList.remove('open');
+        document.body.classList.remove('no-scroll');
+        btn.setAttribute('aria-expanded', 'false');
+      };
       btn.addEventListener('click', () => {
         const open = nav.classList.toggle('open');
         btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        document.body.classList.toggle('no-scroll', open);
       });
-      window.addEventListener('scroll', () => nav.classList.remove('open'), {passive:true});
-    }
-    links?.forEach(a => {
-      a.addEventListener('click', e => {
-        nav?.classList.remove('open');
-        btn?.setAttribute('aria-expanded','false');
-        if (a.hash) {
-          const id = a.hash.slice(1);
-          const target = document.getElementById(id);
-          if (target) {
-            e.preventDefault();
-            const y = target.getBoundingClientRect().top + window.scrollY - 80;
-            window.scrollTo({top:y, behavior:'smooth'});
+      window.addEventListener('scroll', closeMenu, {passive:true});
+      links.forEach(a => {
+        a.addEventListener('click', e => {
+          closeMenu();
+          if (a.hash) {
+            const id = a.hash.slice(1);
+            const target = document.getElementById(id);
+            if (target) {
+              e.preventDefault();
+              const y = target.getBoundingClientRect().top + window.scrollY - 80;
+              window.scrollTo({top:y, behavior:'smooth'});
+            }
           }
-        }
+        });
       });
-    });
+    }
 
     // Order ahead placeholder
     document.getElementById('orderAhead')?.addEventListener('click', ()=>alert('Ordering ahead coming soon!'));


### PR DESCRIPTION
## Summary
- add visually hidden skip-to-content link
- lock body scroll when mobile menu is open

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899dba084888320bba9e3a3e4770e5b