### PR TITLE
Fix mobile hero visibility and remove broken gallery images

### DIFF
--- a/partials/cafe.html
+++ b/partials/cafe.html
@@ -24,10 +24,11 @@
     
 
     /* Hero with background image */
-    #cafe-demo .hero{position:relative;color:#fff}
+    /* Ensure the hero always has visible height on mobile */
+    #cafe-demo .hero{position:relative;color:#fff;min-height:72vh}
     #cafe-demo .hero .bg{position:absolute;inset:0;background:url('https://images.unsplash.com/photo-1498804103079-a6351b050096?q=80&w=1920&auto=format&fit=crop') center/cover no-repeat;filter:saturate(1.05);will-change:transform}
     #cafe-demo .hero .overlay{position:absolute;inset:0;background:linear-gradient(180deg,rgba(27,20,16,.55),rgba(27,20,16,.78))}
-    #cafe-demo .hero .inner{position:relative;padding:120px 0 60px}
+    #cafe-demo .hero .inner{position:relative;padding:96px 0 44px}
     #cafe-demo .eyebrow{letter-spacing:.14em;text-transform:uppercase;font-size:12px;color:#a7f3d0;font-weight:800}
     #cafe-demo h1{font-family:"Playfair Display",Georgia,serif;font-size:44px;line-height:1.08;margin:10px 0 12px}
     #cafe-demo .lead{max-width:60ch;color:#e7f2fb}
@@ -88,10 +89,9 @@
     @media(max-width:900px){#cafe-demo .two{grid-template-columns:1fr}}
     @media(max-width:900px){#cafe-demo .gallery{column-count:2}}
 @media(max-width:520px){#cafe-demo .container{padding:0 16px}#cafe-demo h1{font-size:32px}#cafe-demo .lead{font-size:16px}#cafe-demo .hero-cta{flex-direction:column;align-items:stretch}#cafe-demo section{padding:52px 0}}
-@media(max-width:520px){#cafe-demo .gallery{column-count:2}}
-@media(max-width:360px){#cafe-demo .gallery{column-count:1}}
     @media(max-width:520px){#cafe-demo .info-row{margin-top:24px}}
-    @media(max-width:520px){#cafe-demo .specials{grid-template-columns:1fr}#cafe-demo .special-card .media{height:200px}}
+    @media (max-width:600px){#cafe-demo .specials{grid-template-columns:1fr}#cafe-demo .special-card .media{height:220px}#cafe-demo .gallery{column-count:2}}
+    @media (max-width:380px){#cafe-demo .gallery{column-count:1}}
 
     /* Specials */
     #cafe-demo .specials{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
@@ -118,6 +118,8 @@
     #cafe-demo .gallery img::after{content:none !important}
     #cafe-demo .gallery figcaption,
     #cafe-demo .gallery .wp-caption-text{display:none !important}
+    /* Hide any orphaned image that renders only its alt text in the gallery section */
+    #cafe-demo #gallery img[alt*="Coffee setup"]{display:none !important}
 
     /* Reveal animations */
     #cafe-demo .reveal{opacity:0;transform:translateY(8px);transition:opacity .6s,transform .6s}
@@ -142,8 +144,8 @@
       pointer-events:none!important;
     }
 
-    /* === Space for our fixed header === */
-    #cafe-demo { padding-top: 72px; }
+    /* Account for iOS safe area and fixed header */
+    #cafe-demo { padding-top: calc(64px + env(safe-area-inset-top)); }
 
     /* === Café header styling === */
     #cafe-demo .rw-site{
@@ -189,8 +191,9 @@
       #cafe-demo #rwMainNav .links a.active:after{display:none}
     }
 
-    #cafe-demo .menu-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:999;opacity:0;pointer-events:none;transition:opacity .2s}
-    body.menu-open #cafe-demo .menu-overlay{opacity:1;pointer-events:auto}
+    /* Make overlay truly off by default; show only when menu is open */
+    #cafe-demo .menu-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:999;opacity:0;pointer-events:none;transition:opacity .2s;display:none}
+    body.menu-open #cafe-demo .menu-overlay{display:block;opacity:1;pointer-events:auto}
     #cafe-demo .info-row{margin-top:28px;margin-bottom:32px;font-size:14px;color:#e8e2d9;text-align:center}
   </style>
   <a class="skip-link" href="#cafe-main">Skip to main content</a>
@@ -419,7 +422,9 @@
       // Clean up any orphaned captions or empty images in the gallery
       const gallery = document.querySelector('#cafe-demo #gallery');
       if (gallery) {
+        // Remove any gallery image that fails to load (prevents alt text showing like "Coffee setup")
         gallery.querySelectorAll('img').forEach(img => {
+          img.addEventListener('error', () => img.remove());
           const src = (img.getAttribute('src') || '').trim();
           if (!src || src === '#' || src === 'undefined') {
             img.remove();


### PR DESCRIPTION
## Summary
- Prevent mobile menu overlay from masking the hero and respect iOS safe-area
- Ensure hero section retains height on phones
- Drop any failed images from the gallery to avoid stray alt text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l partials/cafe.html`


------
https://chatgpt.com/codex/tasks/task_e_6899e548b724832087f45ff9c1f82397